### PR TITLE
Hot-fixing date format of UTCTime in MiniASN1_DER

### DIFF
--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -122,8 +122,11 @@ struct MiniASN1DER {
     
     static func UTCTime(_ value: Date) -> [UInt8] {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyMMddHHmmss"
-        let s = formatter.string(from: value) + "Z"
+        formatter.dateFormat = "yyMMddHHmmss'Z'"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        formatter.amSymbol = ""
+        formatter.pmSymbol = ""
+        let s = formatter.string(from: value)
         let b = s.data(using: .ascii)!
         
         return il(tag: 23, length: UInt(b.count)) + b

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -129,7 +129,7 @@ struct MiniASN1DER {
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         formatter.locale = Locale(identifier: "en_US_POSIX")
         
-        let s = formatter.string(from: value).trimmingCharacters(in:.whitespacesAndNewlines)
+        let s = formatter.string(from: value)
         let b = s.data(using: .ascii)!
         
         return il(tag: 23, length: UInt(b.count)) + b

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -124,8 +124,12 @@ struct MiniASN1DER {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyMMddHHmmss'Z'"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
+        
+        // It has been reported that on some iOS devices AM/PM is still part
+        // of the output even though dateFormat doesn't contain an 'a' symbol
         formatter.amSymbol = ""
         formatter.pmSymbol = ""
+        
         let s = formatter.string(from: value)
         let b = s.data(using: .ascii)!
         

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -125,6 +125,10 @@ struct MiniASN1DER {
         formatter.dateFormat = "yyMMddHHmmss'Z'"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         
+        // Recommended for fixed format dates
+        // https://developer.apple.com/documentation/foundation/dateformatter
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        
         // It has been reported that on some iOS devices AM/PM is still part
         // of the output even though dateFormat doesn't contain an 'a' symbol
         formatter.amSymbol = ""

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -122,7 +122,7 @@ struct MiniASN1DER {
     
     static func UTCTime(_ value: Date) -> [UInt8] {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyMMddHHmmss'Z'"
+        formatter.dateFormat = "yyMMddHHmmssa'Z'"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         
         // It has been reported that on some iOS devices AM/PM is still part

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -123,16 +123,11 @@ struct MiniASN1DER {
     static func UTCTime(_ value: Date) -> [UInt8] {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyMMddHHmmss'Z'"
+        
+        // Setup for fixed format dates
+        // as per https://developer.apple.com/documentation/foundation/dateformatter
         formatter.timeZone = TimeZone(abbreviation: "UTC")
-        
-        // Recommended for fixed format dates
-        // https://developer.apple.com/documentation/foundation/dateformatter
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        
-        // It has been reported that on some iOS devices AM/PM is still part
-        // of the output even though dateFormat doesn't contain an 'a' symbol
-        formatter.amSymbol = ""
-        formatter.pmSymbol = ""
         
         let s = formatter.string(from: value).trimmingCharacters(in:.whitespacesAndNewlines)
         let b = s.data(using: .ascii)!

--- a/seacat/miniasn1/MiniASN1_DER.swift
+++ b/seacat/miniasn1/MiniASN1_DER.swift
@@ -122,7 +122,7 @@ struct MiniASN1DER {
     
     static func UTCTime(_ value: Date) -> [UInt8] {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyMMddHHmmssa'Z'"
+        formatter.dateFormat = "yyMMddHHmmss'Z'"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         
         // It has been reported that on some iOS devices AM/PM is still part
@@ -130,7 +130,7 @@ struct MiniASN1DER {
         formatter.amSymbol = ""
         formatter.pmSymbol = ""
         
-        let s = formatter.string(from: value)
+        let s = formatter.string(from: value).trimmingCharacters(in:.whitespacesAndNewlines)
         let b = s.data(using: .ascii)!
         
         return il(tag: 23, length: UInt(b.count)) + b


### PR DESCRIPTION
Hot-fixing date format of UTCTime in MiniASN1_DER to produce UTC datetime string without AM/PM symbols.